### PR TITLE
Refactor RequestService and Entities for Request Status Support and User-Pool Relationship

### DIFF
--- a/src/main/java/com/vit/carpool/controllers/RequestController.java
+++ b/src/main/java/com/vit/carpool/controllers/RequestController.java
@@ -3,7 +3,9 @@ package com.vit.carpool.controllers;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,44 +28,90 @@ public class RequestController {
 
     // Route to retrieve all requests
     @GetMapping
-    public ResponseEntity<List<Request>> getAllRequests() {
-        List<Request> requests = requestService.getAllRequests();
-        return ResponseEntity.ok(requests);
+    public ResponseEntity<?> getAllRequests(String creatorId, String userId, Long poolId) {
+        StringBuilder query = new StringBuilder("SELECT * FROM request WHERE 1=1");
+        MapSqlParameterSource params = new MapSqlParameterSource();
+
+        if (creatorId != null) {
+            query.append(" AND creator_id = :creatorId");
+            params.addValue("creatorId", creatorId);
+        }
+
+        if (userId != null) {
+            query.append(" AND user_id = :userId");
+            params.addValue("userId", userId);
+        }
+
+        if (poolId != null) {
+            query.append(" AND pool_id = :poolId");
+            params.addValue("poolId", poolId);
+        }
+
+        try {
+            List<Request> requests = requestService.getAllRequests();
+            return ResponseEntity.ok(requests);
+        } catch (Exception e) {
+            return new ResponseEntity<>("Error retrieving requests: " + e.getMessage(),
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // Route to find a request by id
     @GetMapping("/{requestId}")
-    public ResponseEntity<Request> getRequestById(@PathVariable long requestId) {
-        Request request = requestService.getRequestById(requestId);
-        return ResponseEntity.ok(request);
+    public ResponseEntity<?> getRequestById(@PathVariable long requestId) {
+        try {
+            Request request = requestService.getRequestById(requestId);
+            return ResponseEntity.ok(request);
+        } catch (Exception e) {
+            return new ResponseEntity<>("Error retrieving request: " + e.getMessage(),
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // Route to create a new request
     @PostMapping
-    public ResponseEntity<Integer> createRequest(@RequestBody Request request) {
-        int result = requestService.createRequest(request);
-        return ResponseEntity.ok(result);
+    public ResponseEntity<?> createRequest(@RequestBody Request request) {
+        try {
+            int result = requestService.createRequest(request);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return new ResponseEntity<>("Error creating request: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // Route to update a request status
     @PutMapping("/{requestId}/status")
-    public ResponseEntity<Integer> updateRequestStatus(@PathVariable long requestId,
+    public ResponseEntity<?> updateRequestStatus(@PathVariable long requestId,
             @RequestBody RequestStatus status) {
-        int result = requestService.updateRequestStatus(requestId, status);
-        return ResponseEntity.ok(result);
+        try {
+            int result = requestService.updateRequestStatus(requestId, status);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return new ResponseEntity<>("Error updating request status: " + e.getMessage(),
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // Route to delete a request
     @DeleteMapping("/{requestId}")
-    public ResponseEntity<Integer> deleteRequest(@PathVariable long requestId) {
-        int result = requestService.deleteRequest(requestId);
-        return ResponseEntity.ok(result);
+    public ResponseEntity<?> deleteRequest(@PathVariable long requestId) {
+        try {
+            int result = requestService.deleteRequest(requestId);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return new ResponseEntity<>("Error deleting request: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // Route to fetch all requests for pools created by a specific user
     @GetMapping("/by-creator/{creatorId}")
-    public ResponseEntity<List<Request>> getRequestsByCreator(@PathVariable String creatorId) {
-        List<Request> requests = requestService.getRequestsByCreator(creatorId);
-        return ResponseEntity.ok(requests);
+    public ResponseEntity<?> getRequestsByCreator(@PathVariable String creatorId) {
+        try {
+            List<Request> requests = requestService.getRequestsByCreator(creatorId);
+            return ResponseEntity.ok(requests);
+        } catch (Exception e) {
+            return new ResponseEntity<>("Error retrieving requests by creator: " + e.getMessage(),
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/main/java/com/vit/carpool/controllers/RequestController.java
+++ b/src/main/java/com/vit/carpool/controllers/RequestController.java
@@ -1,0 +1,69 @@
+package com.vit.carpool.controllers;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.vit.carpool.entities.Request;
+import com.vit.carpool.enums.RequestStatus;
+import com.vit.carpool.services.RequestService;
+
+@RestController
+@RequestMapping("/api/requests")
+public class RequestController {
+
+    @Autowired
+    private RequestService requestService;
+
+    // Route to retrieve all requests
+    @GetMapping
+    public ResponseEntity<List<Request>> getAllRequests() {
+        List<Request> requests = requestService.getAllRequests();
+        return ResponseEntity.ok(requests);
+    }
+
+    // Route to find a request by id
+    @GetMapping("/{requestId}")
+    public ResponseEntity<Request> getRequestById(@PathVariable long requestId) {
+        Request request = requestService.getRequestById(requestId);
+        return ResponseEntity.ok(request);
+    }
+
+    // Route to create a new request
+    @PostMapping
+    public ResponseEntity<Integer> createRequest(@RequestBody Request request) {
+        int result = requestService.createRequest(request);
+        return ResponseEntity.ok(result);
+    }
+
+    // Route to update a request status
+    @PutMapping("/{requestId}/status")
+    public ResponseEntity<Integer> updateRequestStatus(@PathVariable long requestId,
+            @RequestBody RequestStatus status) {
+        int result = requestService.updateRequestStatus(requestId, status);
+        return ResponseEntity.ok(result);
+    }
+
+    // Route to delete a request
+    @DeleteMapping("/{requestId}")
+    public ResponseEntity<Integer> deleteRequest(@PathVariable long requestId) {
+        int result = requestService.deleteRequest(requestId);
+        return ResponseEntity.ok(result);
+    }
+
+    // Route to fetch all requests for pools created by a specific user
+    @GetMapping("/by-creator/{creatorId}")
+    public ResponseEntity<List<Request>> getRequestsByCreator(@PathVariable String creatorId) {
+        List<Request> requests = requestService.getRequestsByCreator(creatorId);
+        return ResponseEntity.ok(requests);
+    }
+}

--- a/src/main/java/com/vit/carpool/controllers/RequestController.java
+++ b/src/main/java/com/vit/carpool/controllers/RequestController.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,24 +27,7 @@ public class RequestController {
 
     // Route to retrieve all requests
     @GetMapping
-    public ResponseEntity<?> getAllRequests(String creatorId, String userId, Long poolId) {
-        StringBuilder query = new StringBuilder("SELECT * FROM request WHERE 1=1");
-        MapSqlParameterSource params = new MapSqlParameterSource();
-
-        if (creatorId != null) {
-            query.append(" AND creator_id = :creatorId");
-            params.addValue("creatorId", creatorId);
-        }
-
-        if (userId != null) {
-            query.append(" AND user_id = :userId");
-            params.addValue("userId", userId);
-        }
-
-        if (poolId != null) {
-            query.append(" AND pool_id = :poolId");
-            params.addValue("poolId", poolId);
-        }
+    public ResponseEntity<?> getAllRequests() {
 
         try {
             List<Request> requests = requestService.getAllRequests();

--- a/src/main/java/com/vit/carpool/controllers/RequestController.java
+++ b/src/main/java/com/vit/carpool/controllers/RequestController.java
@@ -41,6 +41,11 @@ public class RequestController {
     // Route to find a request by id
     @GetMapping("/{requestId}")
     public ResponseEntity<?> getRequestById(@PathVariable long requestId) {
+        if (requestId < 0) {
+            return new ResponseEntity<>("Invalid request ID", HttpStatus.BAD_REQUEST);
+        } else {
+            System.out.println(requestId);
+        }
         try {
             Request request = requestService.getRequestById(requestId);
             return ResponseEntity.ok(request);

--- a/src/main/java/com/vit/carpool/controllers/RequestController.java
+++ b/src/main/java/com/vit/carpool/controllers/RequestController.java
@@ -43,8 +43,6 @@ public class RequestController {
     public ResponseEntity<?> getRequestById(@PathVariable long requestId) {
         if (requestId < 0) {
             return new ResponseEntity<>("Invalid request ID", HttpStatus.BAD_REQUEST);
-        } else {
-            System.out.println(requestId);
         }
         try {
             Request request = requestService.getRequestById(requestId);

--- a/src/main/java/com/vit/carpool/controllers/hello.java
+++ b/src/main/java/com/vit/carpool/controllers/hello.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class hello {
     @GetMapping("/hello")
-    public String hello() {
+    public String Hello() {
         return "Hello!";
     }
 }

--- a/src/main/java/com/vit/carpool/entities/User.java
+++ b/src/main/java/com/vit/carpool/entities/User.java
@@ -5,7 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 @Entity
@@ -19,7 +19,7 @@ public class User {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @OneToMany(mappedBy = "creator", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "creator", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Pool createdPools; // Single pool created by the user
 
     public String getRegistrationNumber() {

--- a/src/main/java/com/vit/carpool/mapper/RequestByIdRowMapper.java
+++ b/src/main/java/com/vit/carpool/mapper/RequestByIdRowMapper.java
@@ -1,0 +1,40 @@
+package com.vit.carpool.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.springframework.jdbc.core.RowMapper;
+
+import com.vit.carpool.entities.Pool;
+import com.vit.carpool.entities.Request;
+import com.vit.carpool.entities.User;
+import com.vit.carpool.enums.RequestStatus;
+
+public class RequestByIdRowMapper implements RowMapper<Request> {
+    @Override
+    public Request mapRow(ResultSet rs, int rowNum) throws SQLException {
+        Request request = new Request();
+
+        Pool pool = new Pool();
+        pool.setPoolID(rs.getLong("pool_id"));
+        pool.setSource(rs.getString("source"));
+        pool.setDestination(rs.getString("destination"));
+        pool.setDate(rs.getDate("date").toLocalDate());
+        pool.setTime(rs.getTime("time").toLocalTime());
+        request.setPool(pool);
+
+        User creator = new User();
+        creator.setRegistrationNumber(rs.getString("creator_id"));
+        creator.setName(rs.getString("creator_name"));
+        request.setCreator(creator);
+
+        User requester = new User();
+        requester.setRegistrationNumber(rs.getString("requester"));
+        requester.setName(rs.getString("requester_name"));
+        request.setUser(requester);
+
+        request.setStatus(RequestStatus.valueOf(rs.getString("status")));
+
+        return request;
+    }
+}

--- a/src/main/java/com/vit/carpool/mapper/RequestRowMapper.java
+++ b/src/main/java/com/vit/carpool/mapper/RequestRowMapper.java
@@ -1,0 +1,35 @@
+package com.vit.carpool.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.springframework.jdbc.core.RowMapper;
+
+import com.vit.carpool.entities.Pool;
+import com.vit.carpool.entities.Request;
+import com.vit.carpool.entities.User;
+import com.vit.carpool.enums.RequestStatus;
+
+public class RequestRowMapper implements RowMapper<Request> {
+
+    @Override
+    public Request mapRow(ResultSet rs, int rowNum) throws SQLException {
+        Request request = new Request();
+        request.setStatus(RequestStatus.valueOf(rs.getString("status")));
+
+        Pool pool = new Pool();
+        pool.setPoolID(rs.getLong("pool_id"));
+        pool.setSource(rs.getString("source"));
+        pool.setDestination(rs.getString("destination"));
+        pool.setDate(rs.getDate("date").toLocalDate());
+        pool.setTime(rs.getTime("time").toLocalTime());
+        request.setPool(pool);
+
+        User requester = new User();
+        requester.setRegistrationNumber(rs.getString("requester"));
+        requester.setName(rs.getString("requester_name"));
+        request.setUser(requester);
+
+        return request;
+    }
+}

--- a/src/main/java/com/vit/carpool/services/RequestService.java
+++ b/src/main/java/com/vit/carpool/services/RequestService.java
@@ -1,0 +1,76 @@
+package com.vit.carpool.services;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.vit.carpool.entities.Request;
+import com.vit.carpool.enums.RequestStatus;
+
+@Service
+public class RequestService {
+
+    @Autowired
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    // Method to retrieve all requests
+    public List<Request> getAllRequests() {
+        String query = "SELECT * FROM request";
+        return namedParameterJdbcTemplate.query(query, new BeanPropertyRowMapper<>(Request.class));
+    }
+
+    // Method to find a request by id
+    public Request getRequestById(long requestId) {
+        String query = "SELECT * FROM request WHERE requestId = :requestId";
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("requestId", requestId);
+        return namedParameterJdbcTemplate.queryForObject(query, params, new BeanPropertyRowMapper<>(Request.class));
+    }
+
+    // Method to create a new request
+    @Transactional
+    public int createRequest(Request request) {
+        String query = "INSERT INTO request (pool_id, creator_id, user_id, status) " +
+                "VALUES (:pool_id, :creator_id, :user_id, :status)";
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("pool_id", request.getPool().getPoolID());
+        params.addValue("creator_id", request.getCreator().getRegistrationNumber());
+        params.addValue("user_id", request.getUser().getRegistrationNumber());
+        params.addValue("status", request.getStatus().name());
+        return namedParameterJdbcTemplate.update(query, params);
+    }
+
+    // Method to update a request status
+    @Transactional
+    public int updateRequestStatus(long requestId, RequestStatus status) {
+        String query = "UPDATE request SET status = :status WHERE requestId = :requestId";
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("status", status.name());
+        params.addValue("requestId", requestId);
+        return namedParameterJdbcTemplate.update(query, params);
+    }
+
+    // Method to delete a request
+    @Transactional
+    public int deleteRequest(long requestId) {
+        String query = "DELETE FROM request WHERE requestId = :requestId";
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("requestId", requestId);
+        return namedParameterJdbcTemplate.update(query, params);
+    }
+
+    // Method to fetch all requests for pools created by a specific user
+    public List<Request> getRequestsByCreator(String creatorId) {
+        String query = "SELECT r.* FROM request r " +
+                "JOIN pool p ON r.pool_id = p.poolID " +
+                "WHERE p.creator_id = :creatorId";
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("creatorId", creatorId);
+        return namedParameterJdbcTemplate.query(query, params, new BeanPropertyRowMapper<>(Request.class));
+    }
+}

--- a/src/main/java/com/vit/carpool/services/RequestService.java
+++ b/src/main/java/com/vit/carpool/services/RequestService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.vit.carpool.entities.Request;
 import com.vit.carpool.enums.RequestStatus;
+import com.vit.carpool.mapper.RequestRowMapper;
 
 @Service
 public class RequestService {
@@ -20,8 +21,26 @@ public class RequestService {
 
     // Method to retrieve all requests
     public List<Request> getAllRequests() {
-        String query = "SELECT * FROM request";
-        return namedParameterJdbcTemplate.query(query, new BeanPropertyRowMapper<>(Request.class));
+        String query = """
+                SELECT
+                	p.poolid as pool_id,
+                    p.source,
+                    p.destination,
+                    p.date,
+                    p.time,
+                    r.status,
+                    u.registrationnumber AS requester,
+                    u.name AS requester_name
+                FROM
+                    request r
+                JOIN
+                    pool p ON r.pool_id = p.poolID
+                JOIN
+                    users u ON r.user_id = u.registrationnumber;
+                                                                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        return namedParameterJdbcTemplate.query(query, params, new RequestRowMapper());
     }
 
     // Method to find a request by id


### PR DESCRIPTION
- Refactored `RequestService` to include support for request status.
- Updated `User` entity to change the relationship with `Pool` from `OneToMany` to `OneToOne`.
- Refactored `Request` entity to add support for request status.
- Created a new `RequestStatus` enum to represent the status of requests.